### PR TITLE
Use vh units instead of JavaScript to make table dimensions 50% of window height.

### DIFF
--- a/nback.css
+++ b/nback.css
@@ -16,6 +16,9 @@ td div {
 }
 
 table {
+	width: 50vh;
+	height: 50vh;
+
 	border-collapse: collapse;
 	margin: auto;
 	background-color: white;

--- a/nback.js
+++ b/nback.js
@@ -1,21 +1,3 @@
-// Size the grid to the window on load
-
-document.ready = function() {
-	var loadwidth = $(window).height();
-	loadwidth *= 0.50;
-	$('table').css({'width':loadwidth+'px'});
-	$('table').css({'height':loadwidth+'px'});
-}
-
-// Resize grid if window is resized
-
-window.onresize = function() {
-	var dynwidth = $(window).height();
-	dynwidth *= 0.50;
-	$('table').css({'width':dynwidth+'px'});
-	$('table').css({'height':dynwidth+'px'});
-}
-
 // Show and hide instructions when prompted
 
 $('#info').click(function() {


### PR DESCRIPTION
It should be [safe][1] to use viewport units, which means that the browser
can resize the table instead of us having to do it in JavaScript.
The viewport size isn't always exactly the same as the window size, but it
should have the same effect of making sure that the table is a
reasonable size.

[1]: http://caniuse.com/#search=vh